### PR TITLE
add EBCC chunking C API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/ebcc/zarr_filter.py
+++ b/ebcc/zarr_filter.py
@@ -13,6 +13,7 @@ class CodecConfigT(ctypes.Structure):
         ('residual_compression_type', ctypes.c_int),
         ('residual_cr', ctypes.c_float),
         ('error', ctypes.c_float),
+        ('chunk_dims', ctypes.c_size_t * 3),
     ]
 
 class EBCCZarrFilter(Codec):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ebcc"
-version = "0.1.3"
+version = "0.1.4"
 description = "Error Bounded Climate Compressor - HDF5 filter for scientific data compression"
 readme = "README.md"
 license = "MIT"

--- a/src/ebcc_codec.c
+++ b/src/ebcc_codec.c
@@ -259,7 +259,10 @@ static int dims_are_valid(const size_t dims[NDIMS]) {
             return FALSE;
         }
     }
-    return image_height >= 32 && dims[NDIMS - 1] >= 32;
+    return image_height >= 32 &&
+            image_height <= EBCC_MAX_INTERNAL_IMAGE_DIM &&
+            dims[NDIMS - 1] >= 32 &&
+            dims[NDIMS - 1] <= EBCC_MAX_INTERNAL_IMAGE_DIM;
 }
 
 static size_t ceil_div_size_t(size_t numerator, size_t denominator) {
@@ -577,8 +580,8 @@ size_t ebcc_encode(float *data, codec_config_t *config, uint8_t **out_buffer) {
     assert_endianness();
 
     if (!dims_are_valid(config->dims)) {
-        log_fatal("Invalid EBCC dimensions: product(dims[0..%d]) and dims[%d] must be at least 32 x 32",
-                NDIMS - 2, NDIMS - 1);
+        log_fatal("Invalid EBCC dimensions: product(dims[0..%d]) and dims[%d] must be between 32 and %d",
+                NDIMS - 2, NDIMS - 1, EBCC_MAX_INTERNAL_IMAGE_DIM);
         return 0;
     }
 
@@ -901,8 +904,8 @@ size_t ebcc_encode_chunking(float *data, codec_config_t *config, uint8_t **out_b
         }
     }
     if (!dims_are_valid(chunk_dims)) {
-        log_fatal("Invalid chunking dimensions: product(chunk_dims[0..%d]) and chunk_dims[%d] must be at least 32 x 32",
-                NDIMS - 2, NDIMS - 1);
+        log_fatal("Invalid chunking dimensions: product(chunk_dims[0..%d]) and chunk_dims[%d] must be between 32 and %d",
+                NDIMS - 2, NDIMS - 1, EBCC_MAX_INTERNAL_IMAGE_DIM);
         return 0;
     }
 
@@ -1270,8 +1273,8 @@ size_t ebcc_decode_chunking(uint8_t *data, size_t data_size, float **out_buffer)
     size_t header_chunk_size = header.chunk_size;
     size_t header_num_chunks = header.num_chunks;
     if (!dims_are_valid(chunk_dims)) {
-        log_fatal("Invalid chunked EBCC data: product(chunk_dims[0..%d]) and chunk_dims[%d] must be at least 32 x 32",
-                NDIMS - 2, NDIMS - 1);
+        log_fatal("Invalid chunked EBCC data: product(chunk_dims[0..%d]) and chunk_dims[%d] must be between 32 and %d",
+                NDIMS - 2, NDIMS - 1, EBCC_MAX_INTERNAL_IMAGE_DIM);
         return 0;
     }
 

--- a/src/ebcc_codec.c
+++ b/src/ebcc_codec.c
@@ -29,6 +29,8 @@
 #define EBCC_HEADER_VERSION 1
 #define EBCC_HEADER_FLAG_CONST_FIELD 0x01
 #define EBCC_HEADER_MAGIC "EBCC"
+#define EBCC_CHUNKING_HEADER_VERSION 1
+#define EBCC_CHUNKING_HEADER_MAGIC "EBCK"
 
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #define EBCC_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
@@ -204,8 +206,20 @@ typedef struct {
     uint64_t tail_size;
 } ebcc_header_t;
 
+typedef struct {
+    uint8_t magic[4];
+    uint32_t version;
+    uint32_t ndims;
+    uint64_t dims[NDIMS];
+    uint64_t chunk_dims[NDIMS];
+    uint64_t num_chunks;
+    uint64_t chunk_size;
+} ebcc_chunking_header_t;
+
 EBCC_STATIC_ASSERT(sizeof(float) == 4, "EBCC serialization requires 32-bit float");
+EBCC_STATIC_ASSERT(sizeof(size_t) == 8, "EBCC chunking serialization requires 64-bit size_t");
 EBCC_STATIC_ASSERT(sizeof(ebcc_header_t) == 48, "EBCC header must be fixed-size");
+EBCC_STATIC_ASSERT(sizeof(ebcc_chunking_header_t) == 80, "EBCC chunking header must be fixed-size");
 
 static uint32_t float_to_bits(float value) {
     uint32_t bits = 0;
@@ -217,6 +231,137 @@ static float bits_to_float(uint32_t bits) {
     float value = 0.0f;
     memcpy(&value, &bits, sizeof(value));
     return value;
+}
+
+static int checked_mul_size_t(size_t a, size_t b, size_t *out) {
+    if (a != 0 && b > SIZE_MAX / a) {
+        return FALSE;
+    }
+    *out = a * b;
+    return TRUE;
+}
+
+static int product_size_t(const size_t values[NDIMS], size_t *out) {
+    size_t product = 1;
+    for (size_t i = 0; i < NDIMS; ++i) {
+        if (!checked_mul_size_t(product, values[i], &product)) {
+            return FALSE;
+        }
+    }
+    *out = product;
+    return TRUE;
+}
+
+static int dims_are_valid(const size_t dims[NDIMS]) {
+    size_t image_height = 1;
+    for (size_t i = 0; i < NDIMS - 1; ++i) {
+        if (dims[i] == 0 || !checked_mul_size_t(image_height, dims[i], &image_height)) {
+            return FALSE;
+        }
+    }
+    return image_height >= 32 && dims[NDIMS - 1] >= 32;
+}
+
+static size_t ceil_div_size_t(size_t numerator, size_t denominator) {
+    return numerator / denominator + (numerator % denominator != 0);
+}
+
+static size_t flat_offset(const size_t indices[NDIMS], const size_t dims[NDIMS]) {
+    size_t offset = indices[0];
+    for (size_t i = 1; i < NDIMS; ++i) {
+        offset = offset * dims[i] + indices[i];
+    }
+    return offset;
+}
+
+static void chunk_origin_from_linear(size_t chunk_linear, const size_t chunk_counts[NDIMS],
+        const size_t chunk_dims[NDIMS], size_t origin[NDIMS]) {
+    for (size_t dim = NDIMS; dim-- > 0;) {
+        size_t chunk_index = chunk_linear % chunk_counts[dim];
+        chunk_linear /= chunk_counts[dim];
+        origin[dim] = chunk_index * chunk_dims[dim];
+    }
+}
+
+static int chunks_are_contiguous_slabs(const size_t dims[NDIMS], const size_t chunk_dims[NDIMS]) {
+    for (size_t dim = 1; dim < NDIMS; ++dim) {
+        if (chunk_dims[dim] != dims[dim]) {
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+static int chunk_fully_in_bounds(const size_t origin[NDIMS], const size_t dims[NDIMS],
+        const size_t chunk_dims[NDIMS]) {
+    for (size_t dim = 0; dim < NDIMS; ++dim) {
+        if (origin[dim] > dims[dim] || chunk_dims[dim] > dims[dim] - origin[dim]) {
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+static void copy_chunk_from_data_padded(const float *data, float *chunk_buffer, const size_t dims[NDIMS],
+        const size_t origin[NDIMS], const size_t chunk_dims[NDIMS], size_t chunk_size) {
+    size_t indices[NDIMS];
+    for (size_t linear = 0; linear < chunk_size; ++linear) {
+        size_t rem = linear;
+        for (size_t dim = NDIMS; dim-- > 0;) {
+            size_t index = origin[dim] + (rem % chunk_dims[dim]);
+            indices[dim] = MIN(index, dims[dim] - 1);
+            rem /= chunk_dims[dim];
+        }
+        chunk_buffer[linear] = data[flat_offset(indices, dims)];
+    }
+}
+
+static void copy_chunk_to_data_unpadded(const float *chunk_buffer, float *data, const size_t dims[NDIMS],
+        const size_t origin[NDIMS], const size_t chunk_dims[NDIMS], size_t chunk_size) {
+    size_t indices[NDIMS];
+    for (size_t linear = 0; linear < chunk_size; ++linear) {
+        size_t rem = linear;
+        int in_bounds = TRUE;
+        for (size_t dim = NDIMS; dim-- > 0;) {
+            indices[dim] = origin[dim] + (rem % chunk_dims[dim]);
+            if (indices[dim] >= dims[dim]) {
+                in_bounds = FALSE;
+            }
+            rem /= chunk_dims[dim];
+        }
+        if (in_bounds) {
+            data[flat_offset(indices, dims)] = chunk_buffer[linear];
+        }
+    }
+}
+
+static int codec_data_buffer_append(codec_data_buffer_t *buffer, const void *src, size_t nbytes) {
+    if (nbytes > SIZE_MAX - buffer->length) {
+        return FALSE;
+    }
+    size_t required_size = buffer->length + nbytes;
+
+    size_t new_size = buffer->size;
+    while (required_size > new_size) {
+        if (new_size > SIZE_MAX / 2) {
+            return FALSE;
+        }
+        new_size *= 2;
+    }
+
+    if (new_size > buffer->size) {
+        uint8_t *new_buffer = (uint8_t *) realloc(buffer->buffer, new_size);
+        if (!new_buffer) {
+            return FALSE;
+        }
+        buffer->buffer = new_buffer;
+        buffer->size = new_size;
+    }
+
+    memcpy(buffer->buffer + buffer->length, src, nbytes);
+    buffer->length += nbytes;
+    buffer->offset = buffer->length;
+    return TRUE;
 }
 
 static void assert_endianness(void) {
@@ -234,6 +379,7 @@ const char* residual_t_names[] = {
 
 void print_config(codec_config_t *config) {
     log_info("dimensions:\t(%lu, %lu, %lu)", config->dims[0], config->dims[1], config->dims[2]);
+    log_info("chunk dimensions:\t(%lu, %lu, %lu)", config->chunk_dims[0], config->chunk_dims[1], config->chunk_dims[2]);
     log_info("base_cr:\t%f", config->base_cr);
     log_info("residual type:\t%s", residual_t_names[config->residual_compression_type]);
     switch (config->residual_compression_type) {
@@ -430,6 +576,11 @@ size_t ebcc_encode(float *data, codec_config_t *config, uint8_t **out_buffer) {
 #endif
     assert_endianness();
 
+    if (!dims_are_valid(config->dims)) {
+        log_fatal("Invalid EBCC dimensions: product(dims[0..%d]) and dims[%d] must be at least 32 x 32",
+                NDIMS - 2, NDIMS - 1);
+        return 0;
+    }
 
     int pure_base_codec_required = FALSE, pure_base_codec_done = FALSE, pure_base_codec_disabled = FALSE, pure_base_codec_consistency_disabled = FALSE, mean_error_adjustment_disabled = FALSE;
     size_t compressed_size = 0, base_codec_buffer_length = 0;
@@ -732,6 +883,130 @@ size_t ebcc_encode(float *data, codec_config_t *config, uint8_t **out_buffer) {
     return out_size;
 }
 
+size_t ebcc_encode_chunking(float *data, codec_config_t *config, uint8_t **out_buffer) {
+    assert_endianness();
+    log_set_level_from_env();
+
+    size_t chunk_dims[NDIMS];
+    int chunk_dims_all_zero = TRUE;
+    for (size_t i = 0; i < NDIMS; ++i) {
+        chunk_dims[i] = config->chunk_dims[i];
+        if (chunk_dims[i] != 0) {
+            chunk_dims_all_zero = FALSE;
+        }
+    }
+    if (chunk_dims_all_zero) {
+        for (size_t i = 0; i < NDIMS; ++i) {
+            chunk_dims[i] = config->dims[i];
+        }
+    }
+    if (!dims_are_valid(chunk_dims)) {
+        log_fatal("Invalid chunking dimensions: product(chunk_dims[0..%d]) and chunk_dims[%d] must be at least 32 x 32",
+                NDIMS - 2, NDIMS - 1);
+        return 0;
+    }
+
+    size_t chunk_counts[NDIMS];
+    for (size_t i = 0; i < NDIMS; ++i) {
+        if (config->dims[i] == 0 || chunk_dims[i] == 0) {
+            log_fatal("Invalid chunking dimensions: dims and chunk_dims must be non-zero");
+            return 0;
+        }
+        chunk_counts[i] = ceil_div_size_t(config->dims[i], chunk_dims[i]);
+    }
+
+    size_t chunk_size = 0, num_chunks = 0, total_size = 0, chunk_bytes = 0;
+    if (!product_size_t(chunk_dims, &chunk_size) ||
+            !product_size_t(chunk_counts, &num_chunks) ||
+            !product_size_t(config->dims, &total_size) ||
+            !checked_mul_size_t(chunk_size, sizeof(float), &chunk_bytes)) {
+        log_fatal("Invalid chunking dimensions: size overflow");
+        return 0;
+    }
+    size_t padded_size = 0;
+    if (!checked_mul_size_t(chunk_size, num_chunks, &padded_size)) {
+        log_fatal("Invalid chunking dimensions: padded size overflow");
+        return 0;
+    }
+    if (padded_size > total_size && padded_size - total_size > total_size / 10) {
+        log_warn("Chunk padding adds %lu values over %lu real values (%.2f%%)",
+                padded_size - total_size, total_size,
+                ((double) (padded_size - total_size) / (double) total_size) * 100.0);
+    }
+    int reuse_chunk_data = chunks_are_contiguous_slabs(config->dims, chunk_dims);
+
+    codec_data_buffer_t output;
+    codec_data_buffer_init(&output);
+
+    ebcc_chunking_header_t header = {0};
+    memcpy(header.magic, EBCC_CHUNKING_HEADER_MAGIC, 4);
+    header.version = EBCC_CHUNKING_HEADER_VERSION;
+    header.ndims = NDIMS;
+    for (size_t i = 0; i < NDIMS; ++i) {
+        header.dims[i] = config->dims[i];
+        header.chunk_dims[i] = chunk_dims[i];
+    }
+    header.num_chunks = num_chunks;
+    header.chunk_size = chunk_size;
+
+    if (!codec_data_buffer_append(&output, &header, sizeof(header))) {
+        log_fatal("Failed to allocate chunked EBCC output header");
+        codec_data_buffer_destroy(&output);
+        return 0;
+    }
+
+    float *chunk_buffer = (float *) malloc(chunk_bytes);
+    if (!chunk_buffer) {
+        log_fatal("Failed to allocate chunk buffer");
+        codec_data_buffer_destroy(&output);
+        return 0;
+    }
+
+    codec_config_t chunk_config = *config;
+    memcpy(chunk_config.dims, chunk_dims, sizeof(chunk_config.dims));
+    for (size_t i = 0; i < NDIMS; ++i) {
+        chunk_config.chunk_dims[i] = 0;
+    }
+
+    for (size_t chunk_linear = 0; chunk_linear < num_chunks; ++chunk_linear) {
+        size_t origin[NDIMS];
+        chunk_origin_from_linear(chunk_linear, chunk_counts, chunk_dims, origin);
+
+        float *chunk_data = chunk_buffer;
+        if (reuse_chunk_data && chunk_fully_in_bounds(origin, config->dims, chunk_dims)) {
+            chunk_data = data + flat_offset(origin, config->dims);
+        } else {
+            copy_chunk_from_data_padded(data, chunk_buffer, config->dims, origin, chunk_dims, chunk_size);
+        }
+
+        uint8_t *chunk_stream = NULL;
+        size_t chunk_stream_size = ebcc_encode(chunk_data, &chunk_config, &chunk_stream);
+        if (chunk_stream_size == 0 || !chunk_stream) {
+            log_fatal("Failed to encode chunk %lu", chunk_linear);
+            free_buffer(chunk_stream);
+            free(chunk_buffer);
+            codec_data_buffer_destroy(&output);
+            return 0;
+        }
+
+        uint64_t chunk_stream_size_u64 = chunk_stream_size;
+        if (!codec_data_buffer_append(&output, &chunk_stream_size_u64, sizeof(chunk_stream_size_u64)) ||
+                !codec_data_buffer_append(&output, chunk_stream, chunk_stream_size)) {
+            log_fatal("Failed to append chunk %lu to chunked EBCC output", chunk_linear);
+            free_buffer(chunk_stream);
+            free(chunk_buffer);
+            codec_data_buffer_destroy(&output);
+            return 0;
+        }
+        free_buffer(chunk_stream);
+    }
+
+    free(chunk_buffer);
+    assert(chunk_size != 0);
+    *out_buffer = output.buffer;
+    return output.length;
+}
+
 void j2k_decode_internal(float **data, size_t *height, size_t *width, float minval, float maxval,
         codec_data_buffer_t *codec_data_buffer) {
     codec_data_buffer_rewind(codec_data_buffer);
@@ -960,6 +1235,126 @@ size_t ebcc_decode(uint8_t *data, size_t data_size, float **out_buffer) {
     }
 
     return tot_size;
+}
+
+size_t ebcc_decode_chunking(uint8_t *data, size_t data_size, float **out_buffer) {
+    assert_endianness();
+    log_set_level_from_env();
+
+    if (data_size < sizeof(ebcc_chunking_header_t) ||
+            memcmp(data, EBCC_CHUNKING_HEADER_MAGIC, 4) != 0) {
+        return ebcc_decode(data, data_size, out_buffer);
+    }
+
+    const uint8_t *iter = data;
+    const uint8_t *end = data + data_size;
+    ebcc_chunking_header_t header;
+    memcpy(&header, iter, sizeof(header));
+    iter += sizeof(header);
+
+    if (header.version != EBCC_CHUNKING_HEADER_VERSION) {
+        log_fatal("Unsupported EBCC chunking header version: %u", header.version);
+        return 0;
+    }
+    if (header.ndims != NDIMS) {
+        log_fatal("Unsupported EBCC chunking dimensionality: %u", header.ndims);
+        return 0;
+    }
+
+    size_t dims[NDIMS];
+    size_t chunk_dims[NDIMS];
+    for (size_t i = 0; i < NDIMS; ++i) {
+        dims[i] = header.dims[i];
+        chunk_dims[i] = header.chunk_dims[i];
+    }
+    size_t header_chunk_size = header.chunk_size;
+    size_t header_num_chunks = header.num_chunks;
+    if (!dims_are_valid(chunk_dims)) {
+        log_fatal("Invalid chunked EBCC data: product(chunk_dims[0..%d]) and chunk_dims[%d] must be at least 32 x 32",
+                NDIMS - 2, NDIMS - 1);
+        return 0;
+    }
+
+    size_t chunk_counts[NDIMS];
+    for (size_t i = 0; i < NDIMS; ++i) {
+        if (dims[i] == 0 || chunk_dims[i] == 0) {
+            log_fatal("Invalid chunked EBCC data: dims and chunk_dims must be non-zero");
+            return 0;
+        }
+        chunk_counts[i] = ceil_div_size_t(dims[i], chunk_dims[i]);
+    }
+
+    size_t expected_chunk_size = 0, expected_num_chunks = 0, total_size = 0, total_bytes = 0;
+    if (!product_size_t(chunk_dims, &expected_chunk_size) ||
+            !product_size_t(chunk_counts, &expected_num_chunks) ||
+            !product_size_t(dims, &total_size) ||
+            !checked_mul_size_t(total_size, sizeof(float), &total_bytes)) {
+        log_fatal("Invalid chunked EBCC data: size overflow");
+        return 0;
+    }
+    if (header_chunk_size != expected_chunk_size || header_num_chunks != expected_num_chunks) {
+        log_fatal("Invalid chunked EBCC data: inconsistent chunk metadata");
+        return 0;
+    }
+    int chunks_are_contiguous = chunks_are_contiguous_slabs(dims, chunk_dims);
+
+    *out_buffer = (float *) malloc(total_bytes);
+    if (!*out_buffer) {
+        log_fatal("Failed to allocate chunked EBCC decode output");
+        return 0;
+    }
+
+    for (size_t chunk_linear = 0; chunk_linear < header_num_chunks; ++chunk_linear) {
+        if ((size_t) (end - iter) < sizeof(uint64_t)) {
+            log_fatal("Invalid chunked EBCC data: missing chunk size");
+            free(*out_buffer);
+            *out_buffer = NULL;
+            return 0;
+        }
+
+        uint64_t chunk_stream_size_u64 = 0;
+        memcpy(&chunk_stream_size_u64, iter, sizeof(chunk_stream_size_u64));
+        iter += sizeof(chunk_stream_size_u64);
+        size_t chunk_stream_size = chunk_stream_size_u64;
+        if (chunk_stream_size > (size_t) (end - iter)) {
+            log_fatal("Invalid chunked EBCC data: truncated chunk payload");
+            free(*out_buffer);
+            *out_buffer = NULL;
+            return 0;
+        }
+
+        float *chunk_buffer = NULL;
+        size_t decoded_chunk_size = ebcc_decode((uint8_t *) iter, chunk_stream_size, &chunk_buffer);
+        if (decoded_chunk_size != header_chunk_size || !chunk_buffer) {
+            log_fatal("Invalid chunked EBCC data: decoded chunk %lu has %lu values, expected %lu",
+                    chunk_linear, decoded_chunk_size, header_chunk_size);
+            free_buffer(chunk_buffer);
+            free(*out_buffer);
+            *out_buffer = NULL;
+            return 0;
+        }
+
+        size_t origin[NDIMS];
+        chunk_origin_from_linear(chunk_linear, chunk_counts, chunk_dims, origin);
+        if (chunks_are_contiguous && chunk_fully_in_bounds(origin, dims, chunk_dims)) {
+            memcpy(*out_buffer + flat_offset(origin, dims), chunk_buffer,
+                    header_chunk_size * sizeof(float));
+        } else {
+            copy_chunk_to_data_unpadded(chunk_buffer, *out_buffer, dims, origin,
+                    chunk_dims, header_chunk_size);
+        }
+        free_buffer(chunk_buffer);
+        iter += chunk_stream_size;
+    }
+
+    if (iter != end) {
+        log_fatal("Invalid chunked EBCC data: trailing payload bytes");
+        free(*out_buffer);
+        *out_buffer = NULL;
+        return 0;
+    }
+
+    return total_size;
 }
 
 void free_buffer(void *buffer) {

--- a/src/ebcc_codec.h
+++ b/src/ebcc_codec.h
@@ -13,6 +13,7 @@
 #endif
 
 #define NDIMS 3
+#define EBCC_MAX_INTERNAL_IMAGE_DIM 2047
 #define EBCC_VERSION_MAJOR 0
 #define EBCC_VERSION_MINOR 1
 

--- a/src/ebcc_codec.h
+++ b/src/ebcc_codec.h
@@ -28,10 +28,13 @@ typedef struct {
     residual_t residual_compression_type;
     float residual_cr;
     float error;
+    size_t chunk_dims[NDIMS];
 } codec_config_t;
 
 EBCC_API size_t ebcc_encode(float *data, codec_config_t *config, uint8_t **out_buffer);
 EBCC_API size_t ebcc_decode(uint8_t *data, size_t data_size, float **out_buffer);
+EBCC_API size_t ebcc_encode_chunking(float *data, codec_config_t *config, uint8_t **out_buffer);
+EBCC_API size_t ebcc_decode_chunking(uint8_t *data, size_t data_size, float **out_buffer);
 EBCC_API void free_buffer(void *buffer);
 
 EBCC_API void print_config(codec_config_t *config);

--- a/src/h5z_ebcc.c
+++ b/src/h5z_ebcc.c
@@ -36,6 +36,10 @@ float uint_ptr_to_double(const unsigned int *ptr) {
 }
 
 EBCC_API void populate_config(codec_config_t *config, size_t cd_nelmts, const unsigned int cd_values[], size_t buf_size) {
+    for (size_t i = 0; i < NDIMS; ++i) {
+        config->chunk_dims[i] = 0;
+    }
+
     config->dims[0] = buf_size / sizeof(float);
     if (config->dims[0] < cd_values[0] * cd_values[1]) {
         log_fatal("Buffer size %lu is smaller than the tile size %lu x %lu = %lu", config->dims[0], cd_values[0], cd_values[1], cd_values[0] * cd_values[1]);

--- a/src/h5z_ebcc.c
+++ b/src/h5z_ebcc.c
@@ -36,27 +36,46 @@ float uint_ptr_to_double(const unsigned int *ptr) {
 }
 
 EBCC_API void populate_config(codec_config_t *config, size_t cd_nelmts, const unsigned int cd_values[], size_t buf_size) {
+    if (cd_nelmts < 4) {
+        log_fatal("EBCC filter requires at least 4 configuration values, got %lu", cd_nelmts);
+        exit(1);
+    }
+
     for (size_t i = 0; i < NDIMS; ++i) {
         config->chunk_dims[i] = 0;
     }
 
+    size_t tile_height = cd_values[0];
+    size_t tile_width = cd_values[1];
+
+    if (tile_height < 32 || tile_width < 32 ||
+            tile_height > EBCC_MAX_INTERNAL_IMAGE_DIM ||
+            tile_width > EBCC_MAX_INTERNAL_IMAGE_DIM) {
+        log_fatal("Tile size %lu x %lu is invalid, each dimension must be between 32 and %d",
+                tile_height, tile_width, EBCC_MAX_INTERNAL_IMAGE_DIM);
+        exit(1);
+    }
+
+    size_t tile_size = tile_height * tile_width;
     config->dims[0] = buf_size / sizeof(float);
-    if (config->dims[0] < cd_values[0] * cd_values[1]) {
-        log_fatal("Buffer size %lu is smaller than the tile size %lu x %lu = %lu", config->dims[0], cd_values[0], cd_values[1], cd_values[0] * cd_values[1]);
+    if (config->dims[0] < tile_size) {
+        log_fatal("Buffer size %lu is smaller than the tile size %lu x %lu = %lu", config->dims[0], tile_height, tile_width, tile_size);
         exit(1);
     }
-    if (config->dims[0] % (cd_values[0] * cd_values[1]) != 0) {
-        log_fatal("Buffer size %lu is not divisible by the tile size %lu x %lu = %lu", config->dims[0], cd_values[0], cd_values[1], cd_values[0] * cd_values[1]);
-        exit(1);
-    }
-    if (cd_values[0] < 32 || cd_values[1] < 32) {
-        log_fatal("Tile size %lu x %lu is too small, must be at least 32 x 32", cd_values[0], cd_values[1]);
+    if (config->dims[0] % tile_size != 0) {
+        log_fatal("Buffer size %lu is not divisible by the tile size %lu x %lu = %lu", config->dims[0], tile_height, tile_width, tile_size);
         exit(1);
     }
     for (size_t i = 0; i < 2; ++i) {
         size_t cur = cd_values[i];
         config->dims[0] /= cur;
         config->dims[i + 1] = cur;
+    }
+    if (config->dims[1] != 0 && config->dims[0] > EBCC_MAX_INTERNAL_IMAGE_DIM / config->dims[1]) {
+        log_fatal("Flattened EBCC image height %lu x %lu exceeds the limit of %d",
+                config->dims[0], config->dims[1],
+                EBCC_MAX_INTERNAL_IMAGE_DIM);
+        exit(1);
     }
 
     config->base_cr = uint_ptr_to_float(&cd_values[2]);

--- a/tests/test_c_api.py
+++ b/tests/test_c_api.py
@@ -1,0 +1,240 @@
+import ctypes
+
+import numpy as np
+import pytest
+from numpy.ctypeslib import ndpointer
+
+try:
+    from ebcc import EBCC_FILTER_PATH
+    from ebcc.zarr_filter import CodecConfigT
+except (FileNotFoundError, ImportError) as exc:
+    pytest.skip(f"EBCC C API library is not available: {exc}", allow_module_level=True)
+
+
+MAX_ERROR = 1
+NDIMS = 3
+
+
+class ChunkingHeader(ctypes.Structure):
+    _fields_ = [
+        ("magic", ctypes.c_ubyte * 4),
+        ("version", ctypes.c_uint32),
+        ("ndims", ctypes.c_uint32),
+        ("dims", ctypes.c_uint64 * NDIMS),
+        ("chunk_dims", ctypes.c_uint64 * NDIMS),
+        ("num_chunks", ctypes.c_uint64),
+        ("chunk_size", ctypes.c_uint64),
+    ]
+
+
+@pytest.fixture(scope="module")
+def ebcc_lib():
+    lib = ctypes.CDLL(EBCC_FILTER_PATH)
+    lib.ebcc_encode.restype = ctypes.c_size_t
+    lib.ebcc_encode.argtypes = [
+        ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
+        ctypes.POINTER(CodecConfigT),
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
+    ]
+    lib.ebcc_decode_chunking.restype = ctypes.c_size_t
+    lib.ebcc_decode_chunking.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_float)),
+    ]
+    lib.ebcc_encode_chunking.restype = ctypes.c_size_t
+    lib.ebcc_encode_chunking.argtypes = [
+        ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
+        ctypes.POINTER(CodecConfigT),
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),
+    ]
+    lib.free_buffer.argtypes = [ctypes.c_void_p]
+    lib.free_buffer.restype = None
+    return lib
+
+
+def make_config(shape, chunk_shape=None, *, base_cr=2.0, error=0.01):
+    config = CodecConfigT()
+    config.dims[:] = shape
+    config.base_cr = base_cr
+    config.residual_compression_type = MAX_ERROR
+    config.residual_cr = 0.0
+    config.error = error
+    config.chunk_dims[:] = chunk_shape or (0, 0, 0)
+    return config
+
+
+def make_data(shape):
+    indices = np.indices(shape, dtype=np.float32)
+    data = indices[0] * 100.0 + indices[1] * 1.5 + indices[2] * 0.25
+    return np.ascontiguousarray(data, dtype=np.float32)
+
+
+def encode_chunking(lib, data, config):
+    out_buffer = ctypes.POINTER(ctypes.c_ubyte)()
+    flattened = np.ascontiguousarray(data, dtype=np.float32).ravel()
+    encoded_size = lib.ebcc_encode_chunking(
+        flattened,
+        ctypes.byref(config),
+        ctypes.byref(out_buffer),
+    )
+    assert encoded_size > 0
+    assert out_buffer
+
+    try:
+        out_array = ctypes.cast(
+            out_buffer,
+            ctypes.POINTER(ctypes.c_ubyte * encoded_size),
+        ).contents
+        return bytes(out_array)
+    finally:
+        lib.free_buffer(out_buffer)
+
+
+def encode_plain(lib, data, config):
+    out_buffer = ctypes.POINTER(ctypes.c_ubyte)()
+    flattened = np.ascontiguousarray(data, dtype=np.float32).ravel()
+    encoded_size = lib.ebcc_encode(
+        flattened,
+        ctypes.byref(config),
+        ctypes.byref(out_buffer),
+    )
+    assert encoded_size > 0
+    assert out_buffer
+
+    try:
+        out_array = ctypes.cast(
+            out_buffer,
+            ctypes.POINTER(ctypes.c_ubyte * encoded_size),
+        ).contents
+        return bytes(out_array)
+    finally:
+        lib.free_buffer(out_buffer)
+
+
+def decode_chunking(lib, encoded, shape):
+    out_buffer = ctypes.POINTER(ctypes.c_float)()
+    encoded_array_type = ctypes.c_ubyte * len(encoded)
+    encoded_buffer = encoded_array_type.from_buffer_copy(encoded)
+    decoded_size = lib.ebcc_decode_chunking(
+        ctypes.byref(encoded_buffer),
+        len(encoded),
+        ctypes.byref(out_buffer),
+    )
+    assert decoded_size == int(np.prod(shape))
+    assert out_buffer
+
+    try:
+        decoded = np.ctypeslib.as_array(out_buffer, shape=(decoded_size,))
+        return decoded.copy().reshape(shape)
+    finally:
+        lib.free_buffer(out_buffer)
+
+
+def read_chunking_header(encoded):
+    assert len(encoded) >= ctypes.sizeof(ChunkingHeader)
+    return ChunkingHeader.from_buffer_copy(encoded)
+
+
+def assert_roundtrip_close(decoded, data):
+    assert decoded.shape == data.shape
+    assert decoded.dtype == data.dtype
+    assert np.allclose(decoded, data, atol=0.02)
+
+
+def test_chunking_header_and_slab_roundtrip(ebcc_lib):
+    shape = (2, 32, 32)
+    chunk_shape = (1, 32, 32)
+    data = make_data(shape)
+
+    encoded = encode_chunking(ebcc_lib, data, make_config(shape, chunk_shape))
+    header = read_chunking_header(encoded)
+
+    assert bytes(header.magic) == b"EBCK"
+    assert header.version == 1
+    assert header.ndims == NDIMS
+    assert tuple(header.dims) == shape
+    assert tuple(header.chunk_dims) == chunk_shape
+    assert header.num_chunks == 2
+    assert header.chunk_size == int(np.prod(chunk_shape))
+
+    decoded = decode_chunking(ebcc_lib, encoded, shape)
+    assert_roundtrip_close(decoded, data)
+
+
+def test_chunking_roundtrip_with_padded_edge_chunks(ebcc_lib):
+    shape = (3, 33, 35)
+    chunk_shape = (2, 32, 32)
+    data = make_data(shape)
+
+    encoded = encode_chunking(ebcc_lib, data, make_config(shape, chunk_shape))
+    header = read_chunking_header(encoded)
+
+    assert tuple(header.dims) == shape
+    assert tuple(header.chunk_dims) == chunk_shape
+    assert header.num_chunks == 8
+    assert header.chunk_size == int(np.prod(chunk_shape))
+
+    decoded = decode_chunking(ebcc_lib, encoded, shape)
+    assert_roundtrip_close(decoded, data)
+
+
+def test_contiguous_chunk_dim_larger_than_data_dim_roundtrip(ebcc_lib):
+    shape = (2, 32, 32)
+    chunk_shape = (4, 32, 32)
+    data = make_data(shape)
+
+    encoded = encode_chunking(ebcc_lib, data, make_config(shape, chunk_shape))
+    header = read_chunking_header(encoded)
+
+    assert tuple(header.dims) == shape
+    assert tuple(header.chunk_dims) == chunk_shape
+    assert header.num_chunks == 1
+    assert header.chunk_size == int(np.prod(chunk_shape))
+
+    decoded = decode_chunking(ebcc_lib, encoded, shape)
+    assert_roundtrip_close(decoded, data)
+
+
+def test_non_contiguous_chunk_dim_larger_than_data_dim_roundtrip(ebcc_lib):
+    shape = (2, 33, 35)
+    chunk_shape = (1, 64, 64)
+    data = make_data(shape)
+
+    encoded = encode_chunking(ebcc_lib, data, make_config(shape, chunk_shape))
+    header = read_chunking_header(encoded)
+
+    assert tuple(header.dims) == shape
+    assert tuple(header.chunk_dims) == chunk_shape
+    assert header.num_chunks == 2
+    assert header.chunk_size == int(np.prod(chunk_shape))
+
+    decoded = decode_chunking(ebcc_lib, encoded, shape)
+    assert_roundtrip_close(decoded, data)
+
+
+def test_zero_chunk_dims_default_to_full_array_chunk(ebcc_lib):
+    shape = (2, 32, 32)
+    data = make_data(shape)
+
+    encoded = encode_chunking(ebcc_lib, data, make_config(shape))
+    header = read_chunking_header(encoded)
+
+    assert tuple(header.chunk_dims) == shape
+    assert header.num_chunks == 1
+    assert header.chunk_size == int(np.prod(shape))
+
+    decoded = decode_chunking(ebcc_lib, encoded, shape)
+    assert_roundtrip_close(decoded, data)
+
+
+def test_decode_chunking_accepts_plain_ebcc_payload(ebcc_lib):
+    shape = (2, 32, 32)
+    data = make_data(shape)
+    config = make_config(shape)
+
+    encoded = encode_plain(ebcc_lib, data, config)
+    assert not encoded.startswith(b"EBCK")
+
+    decoded = decode_chunking(ebcc_lib, encoded, shape)
+    assert_roundtrip_close(decoded, data)


### PR DESCRIPTION
## Summary
- add chunked EBCC encode/decode entry points with a serialized chunking header
- support default full-array chunking, slab reuse, padded edge chunks, and decode fallback for non-chunked EBCC payloads
- extend the Python ctypes config layout and initialize chunk dimensions in the HDF5 config path
- add ctypes C-API tests covering headers, contiguous and non-contiguous chunks, oversize chunk dimensions, and roundtrip behavior
- fix CI checkout so submodules can resolve pinned commits behind annotated tags

## Validation
- .venv/bin/python -m pytest tests/test_c_api.py